### PR TITLE
Save timezone aware timestamps for datasets timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.1.0 (2019-07-02)
+- Changed all `TIMSTAMP` to `TIMSTAMPTZ` in the mara tables. You have to manually run the
+  below migration commands as `make migrate-mara-db` won't pick up this change.
+
+**required changes**
+You need to manually convert the mara tables to `TIMESTAMPTZ`:
+
+```SQL
+-- Change the timezone to whatever your ETL process is running in
+ALTER TABLE data_set_query ALTER created_at TYPE timestamptz
+  USING created_at AT TIME ZONE 'Europe/Berlin';
+ALTER TABLE data_set_query ALTER updated_at TYPE timestamptz
+  USING updated_at AT TIME ZONE 'Europe/Berlin';
+```
+
+
 ## 2.0.1
 Include data_set_id to download_csv endpoint in order to know from which data set is coming from
 

--- a/data_sets/query.py
+++ b/data_sets/query.py
@@ -49,9 +49,9 @@ class Query(Base):
     sort_order = sqlalchemy.Column(sqlalchemy.TEXT)
     filters = sqlalchemy.Column(sqlalchemy.JSON)
 
-    created_at = sqlalchemy.Column(sqlalchemy.TIMESTAMP, nullable=False)
+    created_at = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True), nullable=False)
     created_by = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
-    updated_at = sqlalchemy.Column(sqlalchemy.TIMESTAMP, nullable=False)
+    updated_at = sqlalchemy.Column(sqlalchemy.TIMESTAMP(timezone=True), nullable=False)
     updated_by = sqlalchemy.Column(sqlalchemy.TEXT, nullable=False)
 
     def __init__(self, data_set_id: str, query_id: str = None, column_names: [str] = None,


### PR DESCRIPTION
This changes the timestamps in all mara tables in data-sets to include timezones. This enables us to properly use these timestamps in monitoring.