### PR TITLE
Add numeric as a valid type in a data set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.1 (2019-07-18)
+* Add numeric as a valid type in a data set
+
 ## 2.1.0 (2019-07-02)
 - Changed all `TIMESTAMP` to `TIMESTAMPTZ` in the mara tables. You have to manually run the
   below migration commands as `make migrate-mara-db` won't pick up this change.

--- a/data_sets/data_set.py
+++ b/data_sets/data_set.py
@@ -81,7 +81,7 @@ ORDER BY attnum""", (self.database_table, self.database_schema))
                 for column_name, column_type in cursor.fetchall():
                     if column_type in ['character varying', 'text']:
                         type = 'text'
-                    elif column_type in ['bigint', 'integer', 'real', 'smallint', 'double precision']:
+                    elif column_type in ['bigint', 'integer', 'real', 'smallint', 'double precision', 'numeric']:
                         type = 'number'
                     elif column_type in ['timestamp', 'timestamp with time zone', 'date']:
                         type = 'date'


### PR DESCRIPTION
We have some KPIs as numeric for easier query results.

I'm not sure if there was a particular reason not to include this. Please comment if there is a specific reason this was left out.